### PR TITLE
Only get FolderManager Instance when needed, but not when importing

### DIFF
--- a/src/pysweepme/EmptyDeviceClass.py
+++ b/src/pysweepme/EmptyDeviceClass.py
@@ -26,8 +26,7 @@ import inspect
 
 from .ErrorMessage import error, debug
 
-from . import FolderManager
-FoMa = FolderManager.FolderManager()
+from .FolderManager import getFoMa
 
 from pysweepme.UserInterface import message_box, message_info, message_balloon, message_log
 
@@ -126,7 +125,7 @@ class EmptyDevice():
         if identifier == "SELF":
             return os.path.abspath(os.path.dirname(inspect.getfile(self.__class__)))
         else: 
-            return FoMa.get_path(identifier)
+            return getFoMa().get_path(identifier)
 
     def get_folder(self, identifier):
         """ same function like get_Folder but more python style """
@@ -141,8 +140,8 @@ class EmptyDevice():
         """ this function checks whether a driver related config file exists """
 
         # if config file directory is changed it must also be changed in version manager!
-        if os.path.isfile(FoMa.get_path("CUSTOMFILES") + os.sep + self.DeviceClassName + ".ini"):
-            _config.read(FoMa.get_path("CUSTOMFILES") + os.sep + self.DeviceClassName + ".ini")
+        if os.path.isfile(getFoMa().get_path("CUSTOMFILES") + os.sep + self.DeviceClassName + ".ini"):
+            _config.read(getFoMa().get_path("CUSTOMFILES") + os.sep + self.DeviceClassName + ".ini")
             return True
         else:
             return False

--- a/src/pysweepme/UserInterface.py
+++ b/src/pysweepme/UserInterface.py
@@ -21,10 +21,7 @@
 # SOFTWARE.
 
 import time
-from pysweepme.FolderManager import FolderManager
-
-FoMa = FolderManager()
-logbook_path = FoMa.get_file("LOGBOOK")
+from .FolderManager import getFoMa
 
 
 def get_input(msg) -> str:
@@ -100,7 +97,7 @@ def message_balloon(msg):
 def message_log(msg, logfilepath=None):
 
     if not logfilepath:
-        logfilepath = logbook_path
+        logfilepath = getFoMa().get_file("LOGBOOK")
 
     with open(logfilepath, "a") as logfile:
         year, month, day, hour, min, sec = time.localtime()[:6]


### PR DESCRIPTION
`import pysweepme`
should not instantiate the FolderManager already, so that the application still has the possibility to do adjustments like setting an instance ID (in case of using multiple instances of SweepMe! / pysweepme