### PR TITLE
Explicitly specify excluded rules

### DIFF
--- a/.github/check_version_uniqueness.py
+++ b/.github/check_version_uniqueness.py
@@ -9,7 +9,7 @@ not_found = False
 
 try:
     subprocess.check_call(
-        [  # noqa: S
+        [  # noqa: S603, S607
             "python",
             "-m",
             "pip",


### PR DESCRIPTION
Directive to exclude whole rulesets seems to be no longer supported.