### PR TITLE
Move port clearing to separate function

### DIFF
--- a/src/pysweepme/__init__.py
+++ b/src/pysweepme/__init__.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 
-__version__ = "1.5.6.4"
+__version__ = "1.5.6.5"
 
 import sys
 


### PR DESCRIPTION
Clearing the port can reset devices under rare circumstances. Therefore, the clearing is moved to a separate function that should be called when needed.