### PR TITLE
Enable an application to define an alternative way for file IO

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,11 +105,15 @@ ignore = [
     "ANN101", "ANN102",
     "D203", "D213", "D406", "D407",
     "G004",  # logging does not have any built-in keyword string interpolation for the message itself, falling back to %s etc. is crap
+    "UP015",  # open mode should be clearly stated, explicit is better than implicit
 ]
 exclude = ["WinFolder.py"]
 
 [tool.ruff.pydocstyle]
 convention = "google"
+
+[tool.ruff.flake8-annotations]
+allow-star-arg-any = true
 
 [tool.ruff.per-file-ignores]
 "tests/*" = ["S101", "SLF001", "INP001"]  # Tests should use assert, are allowed to test private internals, and aren't a package

--- a/src/pysweepme/Config.py
+++ b/src/pysweepme/Config.py
@@ -21,22 +21,18 @@
 # SOFTWARE.
 
 import os
+from configparser import ConfigParser
 
 from pysweepme.ErrorMessage import error
 from pysweepme.FolderManager import getFoMa
-from configparser import ConfigParser
 
 
 def is_nonprimary_instance() -> bool:
-    if getFoMa().get_instance_id():
-        return True
-    else:
-        return False
+    return bool(getFoMa().get_instance_id())
 
 
 def get_write_mode() -> str:
-    """
-    The write mode overwrite 'w' for file operations, except when this pysweepme instance is not the only / first
+    """The write mode overwrite 'w' for file operations, except when this pysweepme instance is not the only / first
     instance. In that case it returns 'r' so that no conflicting write operations can occur.
 
     Returns:
@@ -49,10 +45,9 @@ def get_write_mode() -> str:
 
 
 class Config(ConfigParser):
-    """ convenience wrapper around ConfigParser to quickly access config files"""
+    """Convenience wrapper around ConfigParser to quickly access config files."""
 
-    def __init__(self, file_name=None):
-
+    def __init__(self, file_name=None) -> None:
         super().__init__()
 
         self.optionxform = str  # type: ignore
@@ -60,39 +55,33 @@ class Config(ConfigParser):
         self.file_name = file_name
 
     def setFileName(self, file_name):
-        """ deprecated """
+        """Deprecated."""
         self.set_filename(file_name)
 
     def set_filename(self, file_name):
         self.file_name = file_name
 
     def isConfigFile(self):
-        """ deprecated """
+        """Deprecated."""
         return self.is_file()
 
     def is_file(self):
-
         try:
-            if os.path.isfile(self.file_name):
-                return True
-            else:
-                return False
+            return bool(os.path.isfile(self.file_name))
         except:
             error()
 
         return False
 
     def readConfigFile(self):
-        """ deprecated """
+        """Deprecated."""
         return self.load_file()
 
     def load_file(self):
-
         try:
             if self.is_file():
-
                 if os.path.exists(self.file_name):
-                    with open(self.file_name, 'r', encoding='utf-8') as cf:
+                    with open(self.file_name, "r", encoding="utf-8") as cf:
                         self.read_file(cf)
                 return True
             else:
@@ -104,18 +93,20 @@ class Config(ConfigParser):
         return False
 
     def makeConfigFile(self):
-        """ deprecated """
+        """Deprecated."""
         return self.create_file()
 
     def create_file(self):
         try:
             if not self.is_file():
                 if is_nonprimary_instance():
-                    raise Exception("Config File cannot be created in multi-instance mode. Please close all SweepMe! "
-                                    "instances and start a single SweepMe! instance first.")
+                    msg = "Config File cannot be created in multi-instance mode. Please close all SweepMe! instances and start a single SweepMe! instance first."
+                    raise Exception(
+                        msg,
+                    )
                 if not os.path.exists(os.path.dirname(self.file_name)):
                     os.mkdir(os.path.dirname(self.file_name))
-                with open(self.file_name, get_write_mode(), encoding='utf-8') as cf:
+                with open(self.file_name, get_write_mode(), encoding="utf-8") as cf:
                     self.write(cf)
 
                 return True
@@ -125,16 +116,18 @@ class Config(ConfigParser):
         return False
 
     def setConfigSection(self, section):
-        """ deprecated """
+        """Deprecated."""
         return self.set_section(section)
 
     def set_section(self, section):
         try:
             if self.load_file():
                 if is_nonprimary_instance():
-                    raise Exception("Cannot save config in multi-instance mode. Please change the configuration "
-                                    "in the primary SweepMe! instance.")
-                with open(self.file_name, get_write_mode(), encoding='utf-8') as cf:
+                    msg = "Cannot save config in multi-instance mode. Please change the configuration in the primary SweepMe! instance."
+                    raise Exception(
+                        msg,
+                    )
+                with open(self.file_name, get_write_mode(), encoding="utf-8") as cf:
                     if not self.has_section(section):
                         self.add_section(section)
                     self.write(cf)
@@ -146,22 +139,22 @@ class Config(ConfigParser):
         return False
 
     def setConfigOption(self, section, option, value):
-        """ deprecated """
+        """Deprecated."""
         return self.set_option(section, option, value)
 
     def set_option(self, section, option, value):
-
         try:
-
             if is_nonprimary_instance():
-                raise Exception("Cannot save config in multi-instance mode. Please change the configuration "
-                                "in the primary SweepMe! instance.")
+                msg = "Cannot save config in multi-instance mode. Please change the configuration in the primary SweepMe! instance."
+                raise Exception(
+                    msg,
+                )
 
             self.set_section(section)
 
             self.set(section, option, value)
 
-            with open(self.file_name, get_write_mode(), encoding='utf-8') as cf:
+            with open(self.file_name, get_write_mode(), encoding="utf-8") as cf:
                 self.write(cf)
             return True
         except:
@@ -171,24 +164,24 @@ class Config(ConfigParser):
 
     def removeConfigOption(self, section, option):
         try:
-            if self.load_file():
-                if self.has_section(section):
-                    if self.has_option(section, option):
-                        if is_nonprimary_instance():
-                            raise Exception("Cannot save config in multi-instance mode. Please change the "
-                                            "configuration in the primary SweepMe! instance.")
-                        self.remove_option(section, option)
+            if self.load_file() and self.has_section(section) and self.has_option(section, option):
+                if is_nonprimary_instance():
+                    msg = "Cannot save config in multi-instance mode. Please change the configuration in the primary SweepMe! instance."
+                    raise Exception(
+                        msg,
+                    )
+                self.remove_option(section, option)
 
-                        with open(self.file_name, get_write_mode(), encoding='utf-8') as cf:
-                            self.write(cf)
+                with open(self.file_name, get_write_mode(), encoding="utf-8") as cf:
+                    self.write(cf)
 
-                        return True
+                return True
             return False
         except:
             error()
 
     def getConfigSections(self):
-        """ deprecated """
+        """Deprecated."""
         return self.get_sections()
 
     def get_sections(self):
@@ -198,35 +191,31 @@ class Config(ConfigParser):
             return []
 
     def getConfigOption(self, section, option):
-        """ deprecated """
+        """Deprecated."""
         return self.get_value(section, option)
 
     def get_value(self, section, option):
-
-        if self.load_file():
-            if section in self:
-                if option.lower() in self[section]:
-                    return self[section][option.lower()]
-                elif option in self[section]:
-                    return self[section][option]
+        if self.load_file() and section in self:
+            if option.lower() in self[section]:
+                return self[section][option.lower()]
+            elif option in self[section]:
+                return self[section][option]
         return False
 
     def getConfigOptions(self, section):
-        """ deprecated """
+        """Deprecated."""
         return self.get_options(section)
 
     def get_options(self, section):
         vals = {}
-        if self.load_file():
-            if section in self:
-                for key in self[section]:
-                    vals[key] = self[section][key]
+        if self.load_file() and section in self:
+            for key in self[section]:
+                vals[key] = self[section][key]
         return vals
 
     def getConfig(self):
-        """ deprecated """
+        """Deprecated."""
         return self.get_values()
 
     def get_values(self):
-        config = {section: self.getConfigOptions(section) for section in self.getConfigSections()}
-        return config
+        return {section: self.getConfigOptions(section) for section in self.getConfigSections()}

--- a/src/pysweepme/Config.py
+++ b/src/pysweepme/Config.py
@@ -20,39 +20,89 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from __future__ import annotations
+
 import os
 from configparser import ConfigParser
+from pathlib import Path
+from types import TracebackType
+from typing import IO, Any, Callable, Protocol, Union, cast
 
 from pysweepme.ErrorMessage import error
-from pysweepme.FolderManager import getFoMa
 
 
-def is_nonprimary_instance() -> bool:
-    return bool(getFoMa().get_instance_id())
+class FileIOContextProtocol(Protocol):
+    def __enter__(self) -> IO[Any]:
+        """Function to return a file descriptor."""
+
+    def __exit__(
+        self,
+        exc_type: type[Exception] | None,
+        exc_value: Exception | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        """Function to close context manager."""
 
 
-def get_write_mode() -> str:
-    """The write mode overwrite 'w' for file operations, except when this pysweepme instance is not the only / first
-    instance. In that case it returns 'r' so that no conflicting write operations can occur.
+class FileIOProtocolWithoutModifiedCheck(Protocol):
+    def open(  # noqa: A003, PLR0913
+        self,
+        mode: str = "r",
+        buffering: int = -1,
+        encoding: str | None = None,
+        errors: str | None = None,
+        newline: str | None = None,
+    ) -> FileIOContextProtocol:
+        """Function to open a file compatible with pathlib.Path when used in a context manager."""
 
-    Returns:
-        The write mode for file operations.
-    """
-    if getFoMa().get_instance_id():
-        return "r"
-    else:
-        return "w"
+
+class FileIOProtocolWithModifiedCheck(FileIOProtocolWithoutModifiedCheck):
+    def set_full_read(self) -> None:
+        """Function that shall be called when a file is read completely.
+
+        If a file was modified by an external program, the user does not need to decide whether to overwrite the file
+        or not, if the respective file was only read after the external modification.
+        """
+
+
+FileIOProtocol = Union[FileIOProtocolWithoutModifiedCheck, FileIOProtocolWithModifiedCheck]
+
+
+class DefaultFileIO:
+    custom_default_file_io: tuple[Callable[[Path | str], FileIOProtocol]] | None = None
+
+    @classmethod
+    def register_custom_default(cls, function: Callable[[Path | str], FileIOProtocol]) -> None:
+        # use a tuple to prevent python from considering it a bound method
+        cls.custom_default_file_io = (function,)
+
+    @staticmethod
+    def pysweepme_default_fileio(file: Path | str) -> FileIOProtocol:
+        # Path has more sophisticated signatures than the FileIOProtocol, so we need to cast the type
+        return cast(FileIOProtocol, Path(file))
+
+    @staticmethod
+    def default_fileio(file: Path | str) -> FileIOProtocol:
+        if DefaultFileIO.custom_default_file_io:
+            return DefaultFileIO.custom_default_file_io[0](file)
+        return DefaultFileIO.pysweepme_default_fileio(file)
 
 
 class Config(ConfigParser):
     """Convenience wrapper around ConfigParser to quickly access config files."""
 
-    def __init__(self, file_name=None) -> None:
+    def __init__(
+        self,
+        file_name: Path | str,
+        custom_reader_writer: Callable[[Path | str], FileIOProtocol] = DefaultFileIO.default_fileio,
+    ) -> None:
         super().__init__()
 
         self.optionxform = str  # type: ignore
 
         self.file_name = file_name
+
+        self.reader_writer = custom_reader_writer(file_name)
 
     def setFileName(self, file_name):
         """Deprecated."""
@@ -77,20 +127,20 @@ class Config(ConfigParser):
         """Deprecated."""
         return self.load_file()
 
-    def load_file(self):
+    def load_file(self) -> bool:
         try:
             if self.is_file():
-                if os.path.exists(self.file_name):
-                    with open(self.file_name, "r", encoding="utf-8") as cf:
-                        self.read_file(cf)
-                return True
+                with self.reader_writer.open("r", encoding="utf-8") as cf:
+                    self.read_file(cf)
+                    if hasattr(self.reader_writer, "set_full_read"):
+                        self.reader_writer.set_full_read()
             else:
                 self.read_string(self.file_name)
-                return True
         except:
             error()
+            return False
 
-        return False
+        return True
 
     def makeConfigFile(self):
         """Deprecated."""
@@ -99,14 +149,10 @@ class Config(ConfigParser):
     def create_file(self):
         try:
             if not self.is_file():
-                if is_nonprimary_instance():
-                    msg = "Config File cannot be created in multi-instance mode. Please close all SweepMe! instances and start a single SweepMe! instance first."
-                    raise Exception(
-                        msg,
-                    )
                 if not os.path.exists(os.path.dirname(self.file_name)):
                     os.mkdir(os.path.dirname(self.file_name))
-                with open(self.file_name, get_write_mode(), encoding="utf-8") as cf:
+
+                with self.reader_writer.open("w", encoding="utf-8") as cf:
                     self.write(cf)
 
                 return True
@@ -119,66 +165,46 @@ class Config(ConfigParser):
         """Deprecated."""
         return self.set_section(section)
 
-    def set_section(self, section):
+    def set_section(self, section: str) -> bool:
         try:
             if self.load_file():
-                if is_nonprimary_instance():
-                    msg = "Cannot save config in multi-instance mode. Please change the configuration in the primary SweepMe! instance."
-                    raise Exception(
-                        msg,
-                    )
-                with open(self.file_name, get_write_mode(), encoding="utf-8") as cf:
-                    if not self.has_section(section):
-                        self.add_section(section)
+                if not self.has_section(section):
+                    self.add_section(section)
+                with self.reader_writer.open("w", encoding="utf-8") as cf:
                     self.write(cf)
-            return True
-
         except:
             error()
+            return False
 
-        return False
+        return True
 
     def setConfigOption(self, section, option, value):
         """Deprecated."""
         return self.set_option(section, option, value)
 
-    def set_option(self, section, option, value):
+    def set_option(self, section: str, option: str, value: str) -> bool:
         try:
-            if is_nonprimary_instance():
-                msg = "Cannot save config in multi-instance mode. Please change the configuration in the primary SweepMe! instance."
-                raise Exception(
-                    msg,
-                )
-
             self.set_section(section)
-
             self.set(section, option, value)
-
-            with open(self.file_name, get_write_mode(), encoding="utf-8") as cf:
+            with self.reader_writer.open("w", encoding="utf-8") as cf:
                 self.write(cf)
-            return True
+        except:
+            error()
+            return False
+
+        return True
+
+    def removeConfigOption(self, section: str, option: str) -> bool:
+        try:
+            if self.load_file() and self.has_section(section) and self.has_option(section, option):
+                self.remove_option(section, option)
+                with self.reader_writer.open("w", encoding="utf-8") as cf:
+                    self.write(cf)
+                return True
         except:
             error()
 
         return False
-
-    def removeConfigOption(self, section, option):
-        try:
-            if self.load_file() and self.has_section(section) and self.has_option(section, option):
-                if is_nonprimary_instance():
-                    msg = "Cannot save config in multi-instance mode. Please change the configuration in the primary SweepMe! instance."
-                    raise Exception(
-                        msg,
-                    )
-                self.remove_option(section, option)
-
-                with open(self.file_name, get_write_mode(), encoding="utf-8") as cf:
-                    self.write(cf)
-
-                return True
-            return False
-        except:
-            error()
 
     def getConfigSections(self):
         """Deprecated."""

--- a/src/pysweepme/pysweepme_types.py
+++ b/src/pysweepme/pysweepme_types.py
@@ -1,0 +1,76 @@
+# The MIT License
+
+# Copyright (c) 2023 SweepMe! GmbH (sweep-me.net)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""This module defines types used in pysweepme."""
+
+from __future__ import annotations
+
+from types import TracebackType
+from typing import IO, Any, Protocol, Union
+
+
+class FileIOContextProtocol(Protocol):
+    """Protocol for a ContextManager for IO Operations."""
+    def __enter__(self) -> IO[Any]:
+        """Function to return a file descriptor."""
+
+    def __exit__(
+        self,
+        exc_type: type[Exception] | None,
+        exc_value: Exception | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        """Function to close context manager."""
+
+
+class FileIOProtocolWithoutModifiedCheck(Protocol):
+    """Protocol for a class with a pathlib.Path compatible open() function that returns a context manager.
+
+    In contrast to Path's open(), this function does not return a file descriptor directly and instead always
+    must be used in conjunction with a `with` statement that will return the file descriptor of the opened file.
+    """
+    def open(  # noqa: A003, PLR0913
+        self,
+        mode: str = "r",
+        buffering: int = -1,
+        encoding: str | None = None,
+        errors: str | None = None,
+        newline: str | None = None,
+    ) -> FileIOContextProtocol:
+        """Function to open a file compatible with pathlib.Path when used in a context manager."""
+
+
+class FileIOProtocolWithModifiedCheck(FileIOProtocolWithoutModifiedCheck):
+    """Protocol for a class with a pathlib.Path compatible open() function that returns a context manager.
+
+    In contrast to Path's open(), this function does not return a file descriptor directly and instead always
+    must be used in conjunction with a `with` statement that will return the file descriptor of the opened file.
+    """
+    def set_full_read(self) -> None:
+        """Function that shall be called when a file is read completely.
+
+        If a file was modified by an external program, the user does not need to decide whether to overwrite the file
+        or not, if the respective file was only read after the external modification.
+        """
+
+
+FileIOProtocol = Union[FileIOProtocolWithoutModifiedCheck, FileIOProtocolWithModifiedCheck]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,46 @@
+"""Test functions for the Config module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+from pysweepme.Config import Config, DefaultFileIO
+from pysweepme.pysweepme_types import FileIOProtocol
+
+
+class MyPath:
+    """An alternative class for testing that is compatible to Path."""
+
+
+class TestDefaultFileIO:
+    """Tests for checking if the default and registering of custom pathlib.Path()-like classes works."""
+
+    def test_default_behaviour(self) -> None:
+        """Test if the standard pathlib.Path() is used without a registered alternative."""
+        # make sure there is no custom registered function
+        DefaultFileIO.custom_default_file_io = None
+        path = DefaultFileIO.default_fileio(".")
+        assert isinstance(path, Path)
+        assert not isinstance(path, MyPath)
+
+    def test_alternative_default(self) -> None:
+        """Test if registering an alternative default for file IO operations works."""
+
+        def get_mypath(_: Path | str) -> FileIOProtocol:
+            return cast(FileIOProtocol, MyPath())
+
+        DefaultFileIO.register_custom_default(get_mypath)
+        path = DefaultFileIO.default_fileio(".")
+        assert isinstance(path, MyPath)
+
+    def test_config_init(self) -> None:
+        """Make sure that the Config is using the registered file IO type from the DefaultFileIO class."""
+        my_path = cast(FileIOProtocol, MyPath())
+
+        def get_mypath(_: Path | str) -> FileIOProtocol:
+            return my_path
+
+        DefaultFileIO.register_custom_default(get_mypath)
+        config = Config(".")
+        assert config.reader_writer is my_path


### PR DESCRIPTION
- By default, pathlib.Path() is used for file IO
- Applications can register an alternative class that shall handle file IO, e.g. if more control is required regarding locking of files and access of files from different instances of applications