### PR TITLE
Remove trigger and process and mark deprecated functions as such

### DIFF
--- a/src/pysweepme/EmptyDeviceClass.py
+++ b/src/pysweepme/EmptyDeviceClass.py
@@ -30,6 +30,7 @@ from configparser import ConfigParser
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, ClassVar
 
+from pysweepme._utils import deprecated
 from pysweepme.UserInterface import message_balloon, message_box, message_info, message_log
 
 from .FolderManager import getFoMa
@@ -144,16 +145,18 @@ class EmptyDevice:
         """
         return self._is_run_stopped
 
+    @deprecated("1.5.7", "Use get_folder() instead.")
     def get_Folder(self, identifier):
+        """Easy access to a folder without the need to import the FolderManager."""
+        return self.get_folder(identifier)
+
+    def get_folder(self, identifier):
         """Easy access to a folder without the need to import the FolderManager."""
         if identifier == "SELF":
             return os.path.abspath(os.path.dirname(inspect.getfile(self.__class__)))
         return getFoMa().get_path(identifier)
 
-    def get_folder(self, identifier):
-        """Same function like get_Folder but more python style."""
-        return self.get_Folder(identifier)
-
+    @deprecated("1.5.7", "Use is_configfile() instead.")
     def isConfigFile(self):
         """deprecated: remains for compatibility reasons."""
         return self.is_configfile()
@@ -166,13 +169,15 @@ class EmptyDevice:
             return True
         return False
 
+    @deprecated("1.5.7", "Use get_configsections() instead.")
     def getConfigSections(self):
         """deprecated: remains for compatibility reasons."""
         return self.get_configsections()
 
     def get_configsections(self):
-        """This function returns all sections of the driver related config file. If not file exists, an empty list
-        is returned.
+        """This function returns all sections of the driver related config file.
+
+        If not file exists, an empty list is returned.
 
         Returns:
             List of Strings
@@ -181,12 +186,14 @@ class EmptyDevice:
             return _config.sections()
         return []
 
+    @deprecated("1.5.7", "Use get_configoptions() instead.")
     def getConfigOptions(self, section):
         """deprecated: remains for compatibility reasons."""
         return self.get_configoptions(section)
 
     def get_configoptions(self, section):
         """This functions returns all key-value options of a given section of the driver related config file.
+
         If the file does not exist, an empty dictionary is returned.
 
         Args:
@@ -201,6 +208,7 @@ class EmptyDevice:
                 vals[key] = _config[section][key]
         return vals
 
+    @deprecated("1.5.7", "Use get_config() instead.")
     def getConfig(self):
         """deprecated: remains for compatibility reasons."""
         return self.get_config()
@@ -299,25 +307,19 @@ class EmptyDevice:
     # def get_CalibrationFile_properties(self, port = ""):
 
     def connect(self):
-        """Function to be overloaded if needed."""
+        """Function to be overridden if needed."""
 
     def disconnect(self):
-        """Function to be overloaded if needed."""
+        """Function to be overridden if needed."""
 
     def initialize(self):
-        """Function to be overloaded if needed."""
+        """Function to be overridden if needed."""
 
     def deinitialize(self):
-        """Function to be overloaded if needed."""
-
-    def poweron(self):
-        """Function to be overloaded if needed."""
-
-    def poweroff(self):
-        """Function to be overloaded if needed."""
+        """Function to be overridden if needed."""
 
     def reconfigure(self, parameters={}, keys=[]):
-        """Function to be overloaded if needed.
+        """Function to be overridden if needed.
 
         if a GUI parameter changes after replacement with global parameters, the device needs to be reconfigure.
         Default behavior is that all parameters are set again and 'configure' is called.
@@ -327,28 +329,34 @@ class EmptyDevice:
         self.configure()
 
     def configure(self):
-        """Function to be overloaded if needed."""
+        """Function to be overridden if needed."""
 
     def unconfigure(self):
-        """Function to be overloaded if needed."""
-        ## TODO: should be removed in future as these lines are anyway not performed if the function is overloaded
+        """Function to be overridden if needed."""
+        ## TODO: should be removed in future as these lines are anyway not performed if the function is overridden
         if self.idlevalue is not None:
             self.value = self.idlevalue
 
+    def poweron(self):
+        """Function to be overridden if needed."""
+
+    def poweroff(self):
+        """Function to be overridden if needed."""
+
     def signin(self):
-        """Function to be overloaded if needed."""
+        """Function to be overridden if needed."""
 
     def signout(self):
-        """Function to be overloaded if needed."""
+        """Function to be overridden if needed."""
 
     def _transfer(self):
-        """Function to be overloaded if needed."""
+        """Function to be overridden if needed."""
 
     def start(self):
-        """Function to be overloaded if needed."""
+        """Function to be overridden if needed."""
 
     def apply(self):
-        """Function to be overloaded if needed."""
+        """Function to be overridden if needed."""
 
     def reach(self) -> None:
         """Actively wait until the applied value is reached.
@@ -357,38 +365,32 @@ class EmptyDevice:
         """
 
     def adapt(self):
-        """Function to be overloaded if needed."""
+        """Function to be overridden if needed."""
 
     def adapt_ready(self):
-        """Function to be overloaded if needed."""
+        """Function to be overridden if needed."""
 
     def trigger_ready(self):
-        """Function to be overloaded if needed."""
-
-    def trigger(self):  # deprecated
-        pass
+        """Function to be overridden if needed."""
 
     def measure(self):
-        """Function to be overloaded if needed."""
+        """Function to be overridden if needed."""
 
     def request_result(self):
-        """Function to be overloaded if needed."""
+        """Function to be overridden if needed."""
 
     def read_result(self):
-        """Function to be overloaded if needed."""
+        """Function to be overridden if needed."""
 
     def process_data(self):
-        """Function to be overloaded if needed."""
+        """Function to be overridden if needed."""
 
     def call(self):
-        """Function to be overloaded if needed."""
+        """Function to be overridden if needed."""
         return [float("nan") for x in self.variables]
 
-    def process(self):
-        """Function to be overloaded if needed."""
-
     def finish(self):
-        """Function to be overloaded if needed."""
+        """Function to be overridden if needed."""
 
     # def set_Parameter(self,feature,value): # not used yet
     # pass

--- a/src/pysweepme/EmptyDeviceClass.py
+++ b/src/pysweepme/EmptyDeviceClass.py
@@ -182,7 +182,7 @@ class EmptyDevice:
         Returns:
             List of Strings
         """
-        if self.isConfigFile():
+        if self.is_configfile():
             return _config.sections()
         return []
 
@@ -203,7 +203,7 @@ class EmptyDevice:
             dict with pairs of key-value options
         """
         vals = {}
-        if self.isConfigFile() and section in _config:
+        if self.is_configfile() and section in _config:
             for key in _config[section]:
                 vals[key] = _config[section][key]
         return vals
@@ -217,7 +217,7 @@ class EmptyDevice:
         """This function returns a representation of the driver related config file by means of a nested dictionary
         that contains for each section a dictionary with the options.
         """
-        return {section: self.getConfigOptions(section) for section in self.getConfigSections()}
+        return {section: self.get_configoptions(section) for section in self.get_configsections()}
 
     def get_GUIparameter(self, parameter):
         """Is overwritten by Device Class to retrieve the GUI parameter selected by the user."""

--- a/src/pysweepme/__init__.py
+++ b/src/pysweepme/__init__.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 
-__version__ = "1.5.6.8"
+__version__ = "1.5.6.9"
 
 import sys
 

--- a/src/pysweepme/_utils.py
+++ b/src/pysweepme/_utils.py
@@ -1,4 +1,5 @@
 import functools
+import inspect
 import re
 from itertools import zip_longest
 from typing import Any, Callable
@@ -31,15 +32,31 @@ def deprecated(
     removed_in: str,
     instructions: str,
     name: str = "",
+    blame_call: bool = True,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     removed_phrase = "in the next release" if _is_version_reached(removed_in) else f"in version {removed_in}"
 
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         if callable(func):
 
+            def get_call_blame() -> str:
+                try:
+                    frame = inspect.stack()[2]  # 0 is get_call_blame(), 1 is _inner()
+                    file = frame.filename
+                    code = (frame.code_context or [""])[0].strip()
+                    line = frame.lineno
+                    blame = f" ['{code.strip()}' in '{file}', line {line}]"
+                except (TypeError, OSError):
+                    blame = ""
+                return blame
+
             @functools.wraps(func)
-            def _inner(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
-                debug(f"{name or func.__name__} is deprecated and will be removed {removed_phrase}. {instructions}")
+            def _inner(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+                blame_call_str = get_call_blame() if blame_call else ""
+                debug(
+                    f"{name or func.__name__}() is deprecated and will be removed {removed_phrase}. "
+                    f"{instructions}{blame_call_str}",
+                )
                 return func(*args, **kwargs)
 
             return _inner

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -34,7 +34,7 @@ class TestDeprecated:
             assert my_func() == "success"
             assert mocked_debug.call_count == 1
             debug_msg = mocked_debug.call_args_list[0].args[0]
-            assert re.search(r"my_func .* deprecated .* removed .* Do not use.", debug_msg)
+            assert re.search(r"my_func\(\) .* deprecated .* removed .* Do not use\..*", debug_msg)
 
     def test_deprecated_decorator_on_method(self) -> None:
         """Test deprecated decorator for function of a class."""
@@ -50,7 +50,7 @@ class TestDeprecated:
             assert MyClass().my_method() == "success"
             assert mocked_debug.call_count == 1
             debug_msg = mocked_debug.call_args_list[0].args[0]
-            assert re.search(r"my_method .* deprecated .* removed .* Do not use.", debug_msg)
+            assert re.search(r"my_method\(\) .* deprecated .* removed .* Do not use\..*", debug_msg)
 
     def test_deprecated_decorator_on_class(self) -> None:
         """Test deprecated decorator for function of a class."""
@@ -65,4 +65,4 @@ class TestDeprecated:
             assert my_class.check == "success"
             assert mocked_debug.call_count == 1
             debug_msg = mocked_debug.call_args_list[0].args[0]
-            assert re.search(r"MyClass .* deprecated .* removed .* Do not use.", debug_msg)
+            assert re.search(r"MyClass\(\) .* deprecated .* removed .* Do not use\..*", debug_msg)


### PR DESCRIPTION
- Removed following semantic functions from EmptyDevice:
  - trigger (use measure instead)
  - process (use process_data to process something before call, or use finish to do cleanup etc.)
- Other deprecated functions of EmptyDevice (because of naming conventions) will trigger a warning message.
- A deprecation warning will also show, where from the deprecated function was called