### PR TITLE
Clear port after connecting to an instrument

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,6 +56,7 @@ jobs:
       run: |
         twine upload --repository-url ${{ vars.PYPI_API_ENDPOINT }} dist/*
     - name: Tag commit
+      id: tag_commit
       if: ${{ (github.ref_name == 'main') || ((inputs.targetenv || 'testpypi') == 'pypi') }}
       run: |
         pip install --no-index --no-deps --find-links=dist/ pysweepme
@@ -64,8 +65,18 @@ jobs:
         {
           Throw "Inspected version $PysweepmeVersion could not be found in any wheels in the dist folder."
         }
-        $TagName = "Release-${PysweepmeVersion}_(${{ inputs.targetenv || 'testpypi' }})"
+        $TagName = "v${PysweepmeVersion}"
         git tag $TagName
         git push origin $TagName
+        "PysweepmeVersion=${PysweepmeVersion}" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        "TagName=${TagName}" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
       shell: pwsh
-        
+    - name: Create github release
+      if: ${{ (github.ref_name == 'main') || ((inputs.targetenv || 'testpypi') == 'pypi') }}
+      uses: ncipollo/release-action@v1
+      with:
+        artifacts: "dist/*"
+        generateReleaseNotes: true
+        makeLatest: true
+        name: ${{ format('pysweepme {0}', steps.tag_commit.outputs.PysweepmeVersion) }}
+        tag: ${{ steps.tag_commit.outputs.TagName }}

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2021-2022 SweepMe! GmbH (sweep-me.net)
+Copyright (c) 2024 SweepMe! GmbH (sweep-me.net)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ Use the command line (cmd) to install/uninstall:
 
 ## Usage
 
-1. copy the drivers to a certain folder in your project folder, e.g "Devices" or to the public folder "CustomDevices"
-2. import pysweepme to your project
-3. use 'get_device' to load a device class
-4. see the source code of the device classes to see which commands are available
+1. Copy the drivers to a certain folder in your project folder, e.g "Devices" or to the public folder "CustomDevices".
+2. Import pysweepme to your project.
+3. Use 'get_driver' to load a driver.
+4. See the source code of the driver to see which commands are available.  
+   A general overview of the semantic functions of a driver can be found in the [SweepMe! wiki](https://wiki.sweep-me.net/wiki/Sequencer_procedure).
 
 ## Example
 
@@ -35,9 +36,10 @@ import pysweepme
 # find a certain folder that is used by SweepMe!
 custom_devices_folder = pysweepme.get_path("CUSTOMDEVICES")
 
-mouse = pysweepme.get_driver("Logger-PC_Mouse", folder=".", port_string="")
 # folder is a path from which instrument drivers will be loaded
 # port is a string, e.g. "COM1" or "GPIB0::24::INSTR"
+mouse = pysweepme.get_driver("Logger-PC_Mouse", folder=".", port_string="")
+mouse.connect()
 
 print(mouse.read())
 ```
@@ -55,46 +57,12 @@ pysweepme. In this case, these packages have to be installed using pip by solvin
 * Some Instrument drivers only work with Windows and will not work with other systems, e.g. due to dll files or certain 
 third-party packages.
 * Instrument drivers can be downloaded from https://sweep-me.net/devices or using the version manager in SweepMe!.
+  Developers can also find the source code of the drivers in our [instrument driver repository on github](https://github.com/SweepMe/instrument-drivers).
 * SweepMe! instrument drivers have two purposes. They have semantic standard function to be used in SweepMe! but also 
 wrap communication commands to easily call them with pysweepme. Not all SweepMe! instrument drivers come with wrapped
 communication commands, yet.
 
 ## Changelog
-* 1.5.5.47
-  * Readme example fixed using port_string as argument
-  * Reformatting of Ports.py
-* 1.5.5.46 
-  * new submodule "UserInterface"
-  * bugfix in get_device with handing over port string
-  * GPIB, USBTMC and TCPIP ports do not use clear() during open and close 
-  * Find TCPIP ports only lists ports registered in visa runtime
-  * Drivers have method 'is_run_stopped'
-* 1.5.5.45 minor fixes
-* 1.5.5.44 bugfix: SweepMe! user data folder is not created like in portable mode if pysweepme is used standalone
-* 1.5.5.33 first release of pysweepme on pypi after release of SweepMe! 1.5.5
+You can find the list of changes on the [releases page on github](https://github.com/SweepMe/pysweepme/releases).
 
-## License
-MIT License
-
-Copyright (c) 2021 - 2022 SweepMe! GmbH (sweep-me.net)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-The WinFolder package has a separate license not covered in this document and
-which can be found in the header of the WinFolder.py file.
+The changelog for pysweepme 1.5.5 is still available in the [README of the 1.5.5 branch](https://github.com/SweepMe/pysweepme/blob/v1.5.5.x/README.md#changelog).

--- a/src/pysweepme/EmptyDeviceClass.py
+++ b/src/pysweepme/EmptyDeviceClass.py
@@ -31,6 +31,7 @@ from copy import deepcopy
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from pysweepme._utils import deprecated
+from pysweepme.Ports import Port
 from pysweepme.UserInterface import message_balloon, message_box, message_info, message_log
 
 from .FolderManager import getFoMa
@@ -299,6 +300,15 @@ class EmptyDevice:
     def get_port(self):
         return self.port
 
+    def clear_port(self) -> None:
+        """Send clear command to the port object if the port manager is used.
+
+        If clearing is not desired for a specific instrument, the driver can override this method and run
+        alternative steps or do nothing at all.
+        """
+        if self.port_manager and hasattr(self, "port") and isinstance(self.port, Port):
+            self.port.clear()
+
     ## can be used by device class to be triggered by button find_Ports
     # def find_Ports(self):
 
@@ -307,7 +317,12 @@ class EmptyDevice:
     # def get_CalibrationFile_properties(self, port = ""):
 
     def connect(self):
-        """Function to be overridden if needed."""
+        """Function to be overridden if needed.
+
+        If overriding the connect() function in your driver, but at the same time using the port manager, you should
+        call `super().connect()` in your connect() function.
+        """
+        self.clear_port()
 
     def disconnect(self):
         """Function to be overridden if needed."""


### PR DESCRIPTION
- When using the port manager, automatically clear port in connect()
- DeviceManager has new functions to obtain only the driver class (no instance) or the module of the driver
- Updated Readme
- No manually maintained Changelog anymore. Changes are generated from pull requests automatically