### PR TITLE
Clear port is performed before (and thus outside) the connect() function of a driver

### DIFF
--- a/src/pysweepme/EmptyDeviceClass.py
+++ b/src/pysweepme/EmptyDeviceClass.py
@@ -307,7 +307,7 @@ class EmptyDevice:
     # def get_CalibrationFile_properties(self, port = ""):
 
     def connect(self):
-        """Function to be overridden if needed."""
+        """Function to be overridden if needed and not using the port manager."""
 
     def disconnect(self):
         """Function to be overridden if needed."""

--- a/src/pysweepme/EmptyDeviceClass.py
+++ b/src/pysweepme/EmptyDeviceClass.py
@@ -31,7 +31,6 @@ from copy import deepcopy
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from pysweepme._utils import deprecated
-from pysweepme.Ports import Port
 from pysweepme.UserInterface import message_balloon, message_box, message_info, message_log
 
 from .FolderManager import getFoMa
@@ -300,15 +299,6 @@ class EmptyDevice:
     def get_port(self):
         return self.port
 
-    def clear_port(self) -> None:
-        """Send clear command to the port object if the port manager is used.
-
-        If clearing is not desired for a specific instrument, the driver can override this method and run
-        alternative steps or do nothing at all.
-        """
-        if self.port_manager and hasattr(self, "port") and isinstance(self.port, Port):
-            self.port.clear()
-
     ## can be used by device class to be triggered by button find_Ports
     # def find_Ports(self):
 
@@ -317,12 +307,7 @@ class EmptyDevice:
     # def get_CalibrationFile_properties(self, port = ""):
 
     def connect(self):
-        """Function to be overridden if needed.
-
-        If overriding the connect() function in your driver, but at the same time using the port manager, you should
-        call `super().connect()` in your connect() function.
-        """
-        self.clear_port()
+        """Function to be overridden if needed."""
 
     def disconnect(self):
         """Function to be overridden if needed."""

--- a/src/pysweepme/PortManager.py
+++ b/src/pysweepme/PortManager.py
@@ -192,8 +192,7 @@ class PortManager(object):
             self._ports[resource].update_properties(properties)
 
         # port is checked if being open and if not, port is opened
-        if self._ports[resource].port_properties["open"] is False:
-            self._ports[resource].open()
+        self.open_port(resource)
 
         return self._ports[resource]
 
@@ -289,8 +288,8 @@ class PortManager(object):
         """
         if resource not in self._ports:
             self._ports[resource] = Ports.get_port(resource)
-        
-        self._ports[resource].open()
+
+        self.open_port(resource)
         identification = self._ports[resource].get_identification()
         self._ports[resource].close()
         self.close_resourcemanager()
@@ -307,6 +306,9 @@ class PortManager(object):
         """
         if self._ports[resource].port_properties["open"] is False:
             self._ports[resource].open()
+
+            if self._ports[resource].port_properties["clear"]:
+                self._ports[resource].clear()
 
     def close_port(self, resource: str) -> None:
         """

--- a/src/pysweepme/Ports.py
+++ b/src/pysweepme/Ports.py
@@ -249,7 +249,8 @@ def get_port(ID, properties={}):
         # in open(), port_properties can further be changed by global PortDialog settings
         port.open()
 
-    # print(port.port_properties)
+    if port.port_properties["clear"]:
+        port.clear()
 
     return port
 
@@ -283,6 +284,7 @@ class PortType(object):
         "delay": 0.0,
         "rstrip": True,
         "debug": False,
+        "clear": True,
     }
 
     def __init__(self):
@@ -524,6 +526,7 @@ class Port(object):
             "type": type(self).__name__[:-4],  # removeing port from the end of the port
             "active": True,
             "open": False,
+            "clear": True,
             "Name": None,
             "NrDevices": 0,
             "debug": False,

--- a/src/pysweepme/Ports.py
+++ b/src/pysweepme/Ports.py
@@ -523,14 +523,22 @@ class Port(object):
         self.port = None
         self.port_ID = ID
         self.port_properties = {
-            "type": type(self).__name__[:-4],  # removeing port from the end of the port
+            # The Port Type, e.g. "COM", "GPIB"
+            "type": type(self).__name__[:-4],  # removing "port" from the end of the port
+            # Do not use active
             "active": True,
+            # Whether the port is currently opened
             "open": False,
+            # If the port shall be cleared at the beginning of a measurement (after it is opened)
             "clear": True,
+            # Do not use Name
             "Name": None,
+            # Deprecated, use device_communication instead
             "NrDevices": 0,
+            # Enable debugging output for the port
             "debug": False,
-            "ID": self.port_ID,  # String to open the device 'COM3', 'GPIB0::1::INSTR', ...
+            # String identifying the port to open 'COM3', 'GPIB0::1::INSTR', ...
+            "ID": self.port_ID,
         }
 
         self.initialize_port_properties()

--- a/src/pysweepme/Ports.py
+++ b/src/pysweepme/Ports.py
@@ -1045,10 +1045,6 @@ class COMport(Port):
             self.port.close()
             self.port.open()
 
-        # for normal COM ports, the clear will only clear the buffer without sending commands to the instrument,
-        # so it is safe to use.
-        self.clear_internal()
-
     def close_internal(self):
         self.port.close()
         self.port_properties["open"] = False

--- a/src/pysweepme/__init__.py
+++ b/src/pysweepme/__init__.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 
-__version__ = "1.5.6.9"
+__version__ = "1.5.6.10"
 
 import sys
 


### PR DESCRIPTION
- clear() is called immediately after a port is opened by the Port Manager
- connect() of EmptyDevice does not do anything
- use `self.port_properties["clear"] = False` to disable running clear() on the port