### PR TITLE
Update build tools versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Install build tools
       run: |
         python -m pip install --upgrade pip
-        pip install build~=0.10.0 twine~=4.0.2
+        pip install build~=1.2.2 twine~=5.1.1
     - name: Build 
       run: |
         python -m build --wheel


### PR DESCRIPTION
Old twine versions fail to upload to pypi, using the latest version fixes the issues