### PR TITLE
Use PortManager to obtain ports in get_driver()

### DIFF
--- a/src/pysweepme/DeviceManager.py
+++ b/src/pysweepme/DeviceManager.py
@@ -30,7 +30,7 @@ from ._utils import deprecated
 from .Architecture import version_info
 from .EmptyDeviceClass import EmptyDevice
 from .ErrorMessage import error
-from .Ports import get_port
+from .PortManager import PortManager
 
 
 def get_main_py_path(path: str) -> str:
@@ -121,7 +121,8 @@ def setup_driver(driver: EmptyDevice, name: str, port_string: str) -> None:
     """
     if port_string != "":
         if driver.port_manager:
-            port = get_port(port_string, driver.port_properties)
+            port_manager = PortManager()
+            port = port_manager.get_port(port_string, driver.port_properties)
             driver.set_port(port)
 
         driver.set_parameters({"Port": port_string, "Device": name})

--- a/src/pysweepme/__init__.py
+++ b/src/pysweepme/__init__.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 
-__version__ = "1.5.6.11"
+__version__ = "1.5.6.12"
 
 import sys
 


### PR DESCRIPTION
Previously, get_driver was obtaining a (new) port from the low-level Ports module every time it was called. This led to errors when the port was already opened, also when combining the same driver in a SweepMe! module and a CustomFunction Script using get_driver(). Now, the PortManager is used consistently.