### PR TITLE
Improve error handling

### DIFF
--- a/src/pysweepme/DeviceManager.py
+++ b/src/pysweepme/DeviceManager.py
@@ -71,7 +71,9 @@ def get_driver_module(folder: str, name: str) -> types.ModuleType:
     except Exception as e:  # noqa: BLE001
         # We don't know what could go wrong, so we catch all exceptions, log the error, and raise an Exception again
         error()
-        msg = f"Cannot load Driver '{name}' from folder {folder}. Please change folder or copy Driver to your project."
+        msg = f"Cannot load Driver '{name}' from folder {folder}."
+        if isinstance(e, FileNotFoundError):
+            msg += " Please change folder or copy Driver to your project."
         raise ImportError(msg) from e
 
     return module

--- a/src/pysweepme/ErrorMessage.py
+++ b/src/pysweepme/ErrorMessage.py
@@ -23,7 +23,6 @@
 from __future__ import annotations
 
 import os
-
 from time import localtime
 from traceback import print_exc
 from typing import Callable
@@ -41,17 +40,23 @@ def try_to_print_traceback() -> None:
         print_exc()
     except UnicodeDecodeError:
         import traceback
+
         # monkeypatching the linecache module
         # so UnicodeDecodeErrors while trying to read a file don't lead to an
         # uncaught Exception but only "empty" lines in the traceback
-        original_updatecache: Callable[[str, dict[str, object] | None], list[str]] = traceback.linecache.updatecache
-        def try_updatecache(filename: str, module_globals:dict[str, object] | None = None) -> list[str]:
+        original_updatecache: Callable[
+            [str, dict[str, object] | None],
+            list[str],
+        ] = traceback.linecache.updatecache  # type: ignore[attr-defined]
+
+        def try_updatecache(filename: str, module_globals: dict[str, object] | None = None) -> list[str]:
             try:
                 return original_updatecache(filename, module_globals)
             except Exception:  # noqa: BLE001 - error handling should also catch any unexpected errors
                 print("<Failed to read file contents>")  # noqa: T201
                 return []
-        traceback.linecache.updatecache = try_updatecache
+
+        traceback.linecache.updatecache = try_updatecache  # type: ignore[attr-defined]
         print_exc()
 
 
@@ -62,15 +67,15 @@ def error(*args: object) -> None:
         *args: The arguments to print to the debug log.
     """
     year, month, day, hour, min, sec = localtime()[:6]
-    print("-"*60)
-    print('Time: %s.%s.%s %02d:%02d:%02d' % (day, month, year, hour, min, sec))
+    print("-" * 60)
+    print("Time: %s.%s.%s %02d:%02d:%02d" % (day, month, year, hour, min, sec))
     if len(args) > 0:
-        print('Message:', *args)
-    print('Python Error:')
+        print("Message:", *args)
+    print("Python Error:")
     try_to_print_traceback()
-    print('-'*60)
-    
-    
+    print("-" * 60)
+
+
 def debug(*args: object, debugmode_only: bool = False) -> None:
     """Print arguments to the debug log.
 
@@ -78,18 +83,12 @@ def debug(*args: object, debugmode_only: bool = False) -> None:
         *args: The arguments to print to the debug log.
         debugmode_only: True if the arguments shall be printed only when debug mode is on.
     """
-    if "SWEEPME_DEBUGMODE" in os.environ:
-        debug_mode = os.environ["SWEEPME_DEBUGMODE"] == "True"
-    else:
-        debug_mode = False
+    debug_mode = os.environ["SWEEPME_DEBUGMODE"] == "True" if "SWEEPME_DEBUGMODE" in os.environ else False
 
-    if not debugmode_only or debug_mode:
-
-        if len(args) > 0:
-            
-            year, month, day, hour, min, sec = localtime()[:6]
-            print("-"*60)
-            print('Debug: %s.%s.%s %02d:%02d:%02d\t' % (day, month, year, hour, min, sec), *args)
+    if (not debugmode_only or debug_mode) and len(args) > 0:
+        year, month, day, hour, min, sec = localtime()[:6]
+        print("-" * 60)
+        print("Debug: %s.%s.%s %02d:%02d:%02d\t" % (day, month, year, hour, min, sec), *args)
 
 
 def debug_only(*args: object) -> None:

--- a/src/pysweepme/ErrorMessage.py
+++ b/src/pysweepme/ErrorMessage.py
@@ -1,17 +1,17 @@
 # The MIT License
-
+#
 # Copyright (c) 2021-2022 SweepMe! GmbH
-
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy of
 # this software and associated documentation files (the "Software"), to deal in
 # the Software without restriction, including without limitation the rights to
 # use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
 # of the Software, and to permit persons to whom the Software is furnished to do
 # so, subject to the following conditions:
-
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -20,11 +20,39 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-
-from traceback import print_exc
-from time import localtime
+from __future__ import annotations
 
 import os
+
+from time import localtime
+from traceback import print_exc
+from typing import Callable
+
+
+def try_to_print_traceback() -> None:
+    """Print a traceback for the most recent python exception.
+
+    If there is a UnicodeDecodeError while trying to print the exception, e.g.
+    because a Python source file containing an error is using non UTF-8 encoding,
+    the function tries to monkey patch the traceback module to skip reading lines
+    from the file and still try to print as many error details as possible.
+    """
+    try:
+        print_exc()
+    except UnicodeDecodeError:
+        import traceback
+        # monkeypatching the linecache module
+        # so UnicodeDecodeErrors while trying to read a file don't lead to an
+        # uncaught Exception but only "empty" lines in the traceback
+        original_updatecache: Callable[[str, dict[str, object] | None], list[str]] = traceback.linecache.updatecache
+        def try_updatecache(filename: str, module_globals:dict[str, object] | None = None) -> list[str]:
+            try:
+                return original_updatecache(filename, module_globals)
+            except Exception:  # noqa: BLE001 - error handling should also catch any unexpected errors
+                print("<Failed to read file contents>")  # noqa: T201
+                return []
+        traceback.linecache.updatecache = try_updatecache
+        print_exc()
 
 
 def error(*args: object) -> None:
@@ -39,7 +67,7 @@ def error(*args: object) -> None:
     if len(args) > 0:
         print('Message:', *args)
     print('Python Error:')
-    print_exc()
+    try_to_print_traceback()
     print('-'*60)
     
     

--- a/src/pysweepme/__init__.py
+++ b/src/pysweepme/__init__.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 
-__version__ = "1.5.6.12"
+__version__ = "1.5.6.13"
 
 import sys
 


### PR DESCRIPTION
Driver or other source files could break the error-handling when they contained non UTF-8 characters. An exception was thrown and a traceback was attempted to be printed, which however failed because the traceback was trying to read the invalid character as well, resulting in another exception.

With this PR, the traceback printing is monkey patched to skip reading a file if there was a UnicodeDecodeError beforehand.