### PR TITLE
New handling of GUI parameters supporting dynamic GUI parameters

### DIFF
--- a/src/pysweepme/__init__.py
+++ b/src/pysweepme/__init__.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 
-__version__ = "1.5.6.13"
+__version__ = "1.5.6.14"
 
 import sys
 


### PR DESCRIPTION
As an alternative to set/get_GUIparameters, a new way of exchanging parameters between the application and the driver has been introduced:
- update_gui_parameters: A function similar to the old set_GUIparameter, i.e. it will return the default GUI parameters for the driver, but in addition it accepts a dictionary with the current values defined in the GUI and the resulting "default" dictionary might depend on other fields in the GUI.
- apply_gui_parameters: A function similar to the old get_GUIparameter, i.e. it gets a dictionary with the GUI parameter values from the GUI. This function is however coupled to the update_gui_parameters and called more often than the old get_GUIparameter, which has the unfortunate side effect that the driver must account for incomplete or invalid input.

In addition, a helper function has been added that provides the information if the driver supports update_gui_parameters or uses the legacy functions.