### PR TITLE
Improve readability of tox output and add typed packages for ruff tests

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -26,4 +26,4 @@ jobs:
         pip install tox~=4.6.1
     - name: Run tox
       run: |
-        tox run-parallel
+        tox run-parallel --parallel-no-spinner

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ description = run ruff linting
 basepython = py39
 deps =
     ruff ~= 0.0.272
+extras = typed
 commands = ruff --ignore=C90,I,N,D,UP,ANN,BLE,A,COM,EM,PIE,T20,Q,RET,SIM,PTH,TD,ERA,PL,TRY,RUF,W291,W293,E722,ARG002,ARG003,E501,E713,B006,E714,E402,S110,S112,B904,SLF001,F401,B018 .
 
 [testenv:black]
@@ -42,11 +43,12 @@ basepython = py39
 deps =
     ruff ~= 0.0.272
 allowlist_externals = git, cmd
+extras = typed
 commands =
     cmd /c "(if exist .tox\reference rmdir /S /Q .tox\reference) && mkdir .tox\reference"
     git fetch origin main
     git --work-tree=.tox/reference restore --source=origin/main -- .
-    cmd /c "cd .tox\reference && python -m venv .venv && .venv\Scripts\activate.bat && python -m pip install -e .[dev]"
+    cmd /c "cd .tox\reference && python -m venv .venv && .venv\Scripts\activate.bat && python -m pip install -e .[dev,typed]"
     cmd /c "copy pyproject.toml .tox\reference\pyproject.toml"
     cmd /c "cd .tox\reference && .venv\Scripts\activate.bat && ruff --format=json . > ..\..\ref.json & exit 0"
     cmd /c "ruff --format=json . > ruff.json & exit 0"


### PR DESCRIPTION
- Don't use the console spinner when running tox, as the github actions clutter the log with a new line every second
- Also install the optional typed dependencies of pysweepme when running the checks