### PR TITLE
Remove workflows for 1.5.6 (in preparation for 1.5.8)

### DIFF
--- a/.github/Check-SemilinearHistory.ps1
+++ b/.github/Check-SemilinearHistory.ps1
@@ -8,9 +8,10 @@ Param(
 $ErrorActionPreference = 'Stop'
 
 $versionBranches = @(
-  "main",
-  "1.5.6",
-  "v1.5.5.x"
+    "main",
+    "1.5.7",
+    "1.5.6",
+    "v1.5.5.x"
 )
 
 git fetch origin $targetBranch
@@ -21,15 +22,13 @@ $commitSource = git rev-parse "origin/$sourceBranch"
 # verify that source branch originates from the latest commit of the target branch
 # (i.e. a fast-forward merge could be performed)
 git merge-base --is-ancestor $commitTarget $commitSource
-if ($LASTEXITCODE -ne "0")
-{
-   throw "Merge would create a non-semilinear history."
+if ($LASTEXITCODE -ne "0") {
+    throw "Merge would create a non-semilinear history."
 }
 
 # the target branch should only contain simple commits and no merges
 $numberOfMergeCommits = git rev-list --min-parents=2 --count "${commitTarget}..${commitSource}"
-if ($numberOfMergeCommits -eq "0")
-{
+if ($numberOfMergeCommits -eq "0") {
     Return
 }
 
@@ -37,13 +36,11 @@ $commonError = "Source Branch contains non-linear history. This is only acceptab
 
 # find the branch that corresponds to the version before
 $index = [array]::IndexOf($versionBranches, $targetBranch)
-if ($index -eq "-1")
-{
+if ($index -eq "-1") {
     throw "$commonError the Target Branch does not correspond to a release version."
 }
 $precedingVersionBranch = $versionBranches[$index + 1]
-if ($precedingVersionBranch -eq $null)
-{
+if ($precedingVersionBranch -eq $null) {
     throw "$commonError there is no preceding version that is allowed to be merged into the Target Branch."
 }
 
@@ -55,13 +52,11 @@ $currentMergeBase = git merge-base "origin/$precedingVersionBranch" "origin/$tar
 # This must be a true descendent of the current merge base, otherwise the merge is not merging the changes from the old version into the new version
 $newMergeBase = git merge-base "origin/$precedingVersionBranch" "origin/$sourceBranch"
 
-if ($currentMergeBase -eq $newMergeBase)
-{
+if ($currentMergeBase -eq $newMergeBase) {
     throw "$commonError the merge into the $targetBranch branch does not include commits from the $precedingVersionBranch branch (merge bases are equal)."
 }
 
 git merge-base --is-ancestor $currentMergeBase $newMergeBase
-if ($LASTEXITCODE -ne "0")
-{
-   throw "$commonError the merge into the $targetBranch branch does not include commits from the $precedingVersionBranch branch (merge bases are in the wrong order)."
+if ($LASTEXITCODE -ne "0") {
+    throw "$commonError the merge into the $targetBranch branch does not include commits from the $precedingVersionBranch branch (merge bases are in the wrong order)."
 }

--- a/.github/workflows/check_version.yml
+++ b/.github/workflows/check_version.yml
@@ -1,10 +1,9 @@
 name: Check Version
 
-on: 
+on:
   pull_request:
     branches:
       - main
-      - '1.5.6'
 
 permissions:
   contents: read
@@ -14,16 +13,15 @@ jobs:
     name: Check Version
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v3
-      with:
-        python-version: "3.9"
-    - name: Install environment
-      run: |
-        python -m pip install --upgrade pip
-        pip install --no-deps .
-    - name: Run version check
-      run: |
-        python .github/check_version_uniqueness.py
-        
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.9"
+      - name: Install environment
+        run: |
+          python -m pip install --upgrade pip
+          pip install --no-deps .
+      - name: Run version check
+        run: |
+          python .github/check_version_uniqueness.py

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,16 @@
 name: Publish
 
-on: 
+on:
   workflow_dispatch:
     inputs:
       targetenv:
-        description: 'Target Environment'
+        description: "Target Environment"
         required: true
-        default: 'testpypi'
+        default: "testpypi"
         type: choice
         options:
-        - testpypi
-        - pypi
+          - testpypi
+          - pypi
 
 permissions:
   contents: write
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Job Summary
         run: |
-          if [[ "${{ github.ref_name }}" != "main" && "${{ github.ref_name }}" != "1.5.6" && "${{ inputs.targetenv || 'testpypi' }}" == "pypi" ]]
+          if [[ "${{ github.ref_name }}" != "main" && "${{ inputs.targetenv || 'testpypi' }}" == "pypi" ]]
           then
           {
               echo "::error::Publishing to PyPI is only allowed from official branches";
@@ -37,46 +37,46 @@ jobs:
     needs: overview
     environment: ${{ inputs.targetenv || 'testpypi' }}
     env:
-      TWINE_USERNAME: '__token__'
+      TWINE_USERNAME: "__token__"
       TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v3
-      with:
-        python-version: "3.9"
-    - name: Install build tools
-      run: |
-        python -m pip install --upgrade pip
-        pip install build~=1.2.2 twine~=6.1.0
-    - name: Build 
-      run: |
-        python -m build --wheel
-    - name: Publish distribution
-      run: |
-        twine upload --repository-url ${{ vars.PYPI_API_ENDPOINT }} dist/*
-    - name: Tag commit
-      id: tag_commit
-      if: ${{ (github.ref_name == 'main') || (github.ref_name == '1.5.6') || ((inputs.targetenv || 'testpypi') == 'pypi') }}
-      run: |
-        pip install --no-index --no-deps --find-links=dist/ pysweepme
-        $PysweepmeVersion = python -c "import importlib.metadata; print(importlib.metadata.version('pysweepme'))"
-        if ( -not (Get-ChildItem -Path dist -Filter "*${PysweepmeVersion}*.whl"))
-        {
-          Throw "Inspected version $PysweepmeVersion could not be found in any wheels in the dist folder."
-        }
-        $TagName = "v${PysweepmeVersion}"
-        git tag $TagName
-        git push origin $TagName
-        "PysweepmeVersion=${PysweepmeVersion}" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-        "TagName=${TagName}" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-      shell: pwsh
-    - name: Create github release
-      if: ${{ (github.ref_name == 'main') || (github.ref_name == '1.5.6') || ((inputs.targetenv || 'testpypi') == 'pypi') }}
-      uses: ncipollo/release-action@v1
-      with:
-        artifacts: "dist/*"
-        generateReleaseNotes: true
-        makeLatest: true
-        name: ${{ format('pysweepme {0}', steps.tag_commit.outputs.PysweepmeVersion) }}
-        tag: ${{ steps.tag_commit.outputs.TagName }}
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.9"
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build~=1.2.2 twine~=6.1.0
+      - name: Build
+        run: |
+          python -m build --wheel
+      - name: Publish distribution
+        run: |
+          twine upload --repository-url ${{ vars.PYPI_API_ENDPOINT }} dist/*
+      - name: Tag commit
+        id: tag_commit
+        if: ${{ (github.ref_name == 'main') || ((inputs.targetenv || 'testpypi') == 'pypi') }}
+        run: |
+          pip install --no-index --no-deps --find-links=dist/ pysweepme
+          $PysweepmeVersion = python -c "import importlib.metadata; print(importlib.metadata.version('pysweepme'))"
+          if ( -not (Get-ChildItem -Path dist -Filter "*${PysweepmeVersion}*.whl"))
+          {
+            Throw "Inspected version $PysweepmeVersion could not be found in any wheels in the dist folder."
+          }
+          $TagName = "v${PysweepmeVersion}"
+          git tag $TagName
+          git push origin $TagName
+          "PysweepmeVersion=${PysweepmeVersion}" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          "TagName=${TagName}" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        shell: pwsh
+      - name: Create github release
+        if: ${{ (github.ref_name == 'main') || ((inputs.targetenv || 'testpypi') == 'pypi') }}
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "dist/*"
+          generateReleaseNotes: true
+          makeLatest: true
+          name: ${{ format('pysweepme {0}', steps.tag_commit.outputs.PysweepmeVersion) }}
+          tag: ${{ steps.tag_commit.outputs.TagName }}

--- a/.github/workflows/semilinear_history.yml
+++ b/.github/workflows/semilinear_history.yml
@@ -1,10 +1,9 @@
 name: Check Semilinear History
 
-on: 
+on:
   pull_request:
     branches:
       - main
-      - '1.5.6'
 
 permissions:
   contents: read
@@ -14,8 +13,8 @@ jobs:
     name: Check Semilinear History
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Check Semilinear History
-      shell: pwsh
-      run: |
-        .\.github\Check-SemilinearHistory.ps1 -targetBranch ${{ github.base_ref }} -sourceBranch ${{ github.head_ref }}
+      - uses: actions/checkout@v3
+      - name: Check Semilinear History
+        shell: pwsh
+        run: |
+          .\.github\Check-SemilinearHistory.ps1 -targetBranch ${{ github.base_ref }} -sourceBranch ${{ github.head_ref }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,10 +1,9 @@
 name: Run Checks
 
-on: 
+on:
   pull_request:
     branches:
       - main
-      - '1.5.6'
 
 permissions:
   contents: read
@@ -15,15 +14,15 @@ jobs:
     runs-on: windows-2022
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v3
-      with:
-        python-version: "3.9"
-    - name: Install tox
-      run: |
-        python -m pip install --upgrade pip
-        pip install tox~=4.6.1
-    - name: Run tox
-      run: |
-        tox run-parallel --parallel-no-spinner
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.9"
+      - name: Install tox
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox~=4.6.1
+      - name: Run tox
+        run: |
+          tox run-parallel --parallel-no-spinner

--- a/src/pysweepme/__init__.py
+++ b/src/pysweepme/__init__.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 
-__version__ = "1.5.7.5"
+__version__ = "1.5.7.6"
 
 import sys
 


### PR DESCRIPTION
Workflows are triggered per branch. Therefore, we don't need to include all triggers for all the branches, but only for the branch the corresponding file is included it. Currently, this is main.