### PR TITLE
Introduce version 1.5.8 and remove deprecated functions

### DIFF
--- a/src/pysweepme/DeviceManager.py
+++ b/src/pysweepme/DeviceManager.py
@@ -26,7 +26,6 @@ import os
 import types
 from pathlib import Path
 
-from ._utils import deprecated
 from .Architecture import version_info
 from .EmptyDeviceClass import EmptyDevice
 from .ErrorMessage import error
@@ -161,6 +160,3 @@ def get_driver(name: str, folder: str = ".", port_string: str = "") -> EmptyDevi
     setup_driver(driver, name, port_string)
 
     return driver
-
-
-get_device = deprecated("1.5.8", "Use get_driver() instead.", name="get_device")(get_driver)

--- a/src/pysweepme/EmptyDeviceClass.py
+++ b/src/pysweepme/EmptyDeviceClass.py
@@ -31,7 +31,6 @@ from configparser import ConfigParser
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from pysweepme._utils import deprecated
 from pysweepme.UserInterface import message_balloon, message_box, message_info, message_log
 
 from .FolderManager import getFoMa
@@ -173,21 +172,11 @@ class EmptyDevice:
         """
         return self._is_run_stopped
 
-    @deprecated("1.5.8", "Use get_folder() instead.")
-    def get_Folder(self, identifier):
-        """Easy access to a folder without the need to import the FolderManager."""
-        return self.get_folder(identifier)
-
     def get_folder(self, identifier):
         """Easy access to a folder without the need to import the FolderManager."""
         if identifier == "SELF":
             return os.path.abspath(os.path.dirname(inspect.getfile(self.__class__)))
         return getFoMa().get_path(identifier)
-
-    @deprecated("1.5.8", "Use is_configfile() instead.")
-    def isConfigFile(self):
-        """deprecated: remains for compatibility reasons."""
-        return self.is_configfile()
 
     def is_configfile(self):
         """This function checks whether a driver related config file exists."""
@@ -196,11 +185,6 @@ class EmptyDevice:
             _config.read(getFoMa().get_path("CUSTOMFILES") + os.sep + self.DeviceClassName + ".ini")
             return True
         return False
-
-    @deprecated("1.5.8", "Use get_configsections() instead.")
-    def getConfigSections(self):
-        """deprecated: remains for compatibility reasons."""
-        return self.get_configsections()
 
     def get_configsections(self):
         """This function returns all sections of the driver related config file.
@@ -213,11 +197,6 @@ class EmptyDevice:
         if self.is_configfile():
             return _config.sections()
         return []
-
-    @deprecated("1.5.8", "Use get_configoptions() instead.")
-    def getConfigOptions(self, section):
-        """deprecated: remains for compatibility reasons."""
-        return self.get_configoptions(section)
 
     def get_configoptions(self, section):
         """This functions returns all key-value options of a given section of the driver related config file.
@@ -235,11 +214,6 @@ class EmptyDevice:
             for key in _config[section]:
                 vals[key] = _config[section][key]
         return vals
-
-    @deprecated("1.5.8", "Use get_config() instead.")
-    def getConfig(self):
-        """deprecated: remains for compatibility reasons."""
-        return self.get_config()
 
     def get_config(self):
         """This function returns a representation of the driver related config file by means of a nested dictionary

--- a/src/pysweepme/__init__.py
+++ b/src/pysweepme/__init__.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 
-__version__ = "1.5.7.6"
+__version__ = "1.5.8.1"
 
 import sys
 
@@ -46,7 +46,7 @@ if sys.platform == "win32":
 
 from .FolderManager import addFolderToPATH, get_path, set_path
 from .EmptyDeviceClass import EmptyDevice
-from .DeviceManager import get_device, get_driver
+from .DeviceManager import get_driver
 from .Ports import get_port, close_port
 from .ErrorMessage import error, debug
 
@@ -58,7 +58,6 @@ __all__ = [
     "EmptyDeviceClass",
     "EmptyDevice",
     "DeviceManager",
-    "get_device",
     "get_driver",
     "Ports",
     "get_port",


### PR DESCRIPTION
Bump version number to 1.5.8.1 (in preparation of SweepMe! 1.5.8 release) and remove deprecated functions.