### PR TITLE
Tag and create release only for official pypi deployments

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,7 +57,7 @@ jobs:
           twine upload --repository-url ${{ vars.PYPI_API_ENDPOINT }} dist/*
       - name: Tag commit
         id: tag_commit
-        if: ${{ (github.ref_name == 'main') || ((inputs.targetenv || 'testpypi') == 'pypi') }}
+        if: ${{ ((inputs.targetenv || 'testpypi') == 'pypi') }}
         run: |
           pip install --no-index --no-deps --find-links=dist/ pysweepme
           $PysweepmeVersion = python -c "import importlib.metadata; print(importlib.metadata.version('pysweepme'))"
@@ -72,7 +72,7 @@ jobs:
           "TagName=${TagName}" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         shell: pwsh
       - name: Create github release
-        if: ${{ (github.ref_name == 'main') || ((inputs.targetenv || 'testpypi') == 'pypi') }}
+        if: ${{ ((inputs.targetenv || 'testpypi') == 'pypi') }}
         uses: ncipollo/release-action@v1
         with:
           artifacts: "dist/*"

--- a/src/pysweepme/__init__.py
+++ b/src/pysweepme/__init__.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 
-__version__ = "1.5.8.1"
+__version__ = "1.5.8.2"
 
 import sys
 


### PR DESCRIPTION
Deployments to testpypi should not be tagged or in the list of github releases.
Deployments to official pypi are guarded to the main branch anyways.